### PR TITLE
Bug Fix: ValueError on message format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-install: pip install tox --use-mirrors
+install: pip install tox
 env:
   - TOX_ENV=py27
   - TOX_ENV=py33

--- a/stoplight/exceptions.py
+++ b/stoplight/exceptions.py
@@ -1,10 +1,17 @@
+import warnings
 
 
 class ValidationFailed(ValueError):
     """User input was inconsistent with API restrictions"""
 
     def __init__(self, msg, *args, **kwargs):
-        msg = msg.format(*args, **kwargs)
+        if len(args) or len(kwargs):
+            warnings.warn(
+                'It is recommended to format the Exception message '
+                'outside the parameters to the Exception.',
+                DeprecationWarning
+            )
+            msg = msg.format(*args, **kwargs)
         super(ValidationFailed, self).__init__(msg)
 
 
@@ -12,5 +19,12 @@ class ValidationProgrammingError(ValueError):
     """Caller did not map validations correctly"""
 
     def __init__(self, msg, *args, **kwargs):
-        msg = msg.format(*args, **kwargs)
+        if len(args) or len(kwargs):
+            warnings.warn(
+                'It is recommended to format the Exception message '
+                'outside the parameters to the Exception.',
+                DeprecationWarning
+            )
+            msg = msg.format(*args, **kwargs)
+            msg = msg.format(*args, **kwargs)
         super(ValidationProgrammingError, self).__init__(msg)

--- a/stoplight/exceptions.py
+++ b/stoplight/exceptions.py
@@ -26,5 +26,4 @@ class ValidationProgrammingError(ValueError):
                 DeprecationWarning
             )
             msg = msg.format(*args, **kwargs)
-            msg = msg.format(*args, **kwargs)
         super(ValidationProgrammingError, self).__init__(msg)

--- a/stoplight/tests/test_validation.py
+++ b/stoplight/tests/test_validation.py
@@ -1,14 +1,18 @@
+import os
+import re
+import threading
 from unittest import TestCase
 
-import threading
+import mock
+
 import stoplight
 from stoplight import *
 from stoplight.exceptions import *
 
-import os
-
 VALIDATED_STR = 'validated'
 globalctx = threading.local()
+
+IS_UPPER_REGEX = re.compile('^[A-Z]*$')
 
 
 @validation_function
@@ -16,7 +20,7 @@ def is_upper(z):
     """Simple validation function for testing purposes
     that ensures that input is all caps
     """
-    if z.upper() != z:
+    if not IS_UPPER_REGEX.match(z):
         raise ValidationFailed('{0} is not uppercase'.format(z))
 
 
@@ -347,7 +351,8 @@ class TestValidationDecorator(TestCase):
         negative_cases = [
             'z', 'y', 'z',
             'ww', 'vv', 'uu',
-            'serial', 'cereal', 'surreal'
+            'serial', 'cereal', 'surreal',
+            '\}', '\{'
         ]
 
         for case in positive_cases:
@@ -647,3 +652,13 @@ class TestValidationDecorator(TestCase):
     def test_free_rule_no_getter(self):
         with self.assertRaises(ValidationProgrammingError):
             res = self.ep.free_rule_no_getter()
+
+    def test_validation_failure_deprecation_warning(self):
+        with mock.patch('warnings.warn') as mock_warning:
+            ValidationFailed('hello {0}', 'world')
+            self.assertEqual(mock_warning.call_count, 1)
+
+    def test_validation_programmering_error_deprecation_warning(self):
+        with mock.patch('warnings.warn') as mock_warning:
+            ValidationProgrammingError('hello {0}', 'world')
+            self.assertEqual(mock_warning.call_count, 1)

--- a/tools/test-requires
+++ b/tools/test-requires
@@ -1,5 +1,6 @@
 coverage
-six
+mock
 nose
-testtools
 pep8
+six
+testtools


### PR DESCRIPTION
- Bug Fix: The stoplight Exceptions were provided a string that
  contained a single brace ({ or }) then it was the `msg.format()`
  line would cause a ValueError to improperly occur.

CLOSES: #12 