### PR TITLE
Enhancement basic infra updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-install: pip install tox --use-mirrors
+install: pip install tox
 env:
   - TOX_ENV=py27
   - TOX_ENV=py33

--- a/stoplight/tests/test_validation.py
+++ b/stoplight/tests/test_validation.py
@@ -43,12 +43,14 @@ def is_type(t):
             raise ValidationFailed('Input is incorrect type')
     return func
 
+
 error_count = 0
 
 
 def abort(code):
     global error_count
     error_count = error_count + 1
+
 
 detailed_errors = list()
 
@@ -201,6 +203,7 @@ PositionRuleProgError = HeaderRule(
 
 def abort_and_raise(msg):
     raise RuntimeError(msg)
+
 
 FunctionalUppercaseRule = Rule(is_upper(),
                                lambda: abort_and_raise('not uppercase'))

--- a/tools/test-requires
+++ b/tools/test-requires
@@ -1,5 +1,6 @@
 coverage
 six
-nose
+pytest-cov==2.5.1
+pytest==3.3.2
 testtools
-pep8
+pycodestyle

--- a/tools/test-requires
+++ b/tools/test-requires
@@ -1,6 +1,7 @@
-coverage
-six
+coverage==4.4.1
+mock==2.0
+six==1.11.0
 pytest-cov==2.5.1
 pytest==3.3.2
-testtools
-pycodestyle
+testtools==2.3.0
+pycodestyle==2.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 [tox]
-envlist = py27,py33,py34,pypy,pep8
+minversion = 2.0
+envlist = py27,{py33,py34,py35,py36},pypy,pep8
+skip_missing_interpreters=True
 
 [testenv] 
 deps = -r{toxinidir}/tools/test-requires
 commands = nosetests {posargs}
 
 [testenv:pep8]
-deps = pep8
+deps = pycodestyle
 
 #NOTE: E128 = Visual indent
-commands = pep8 --exclude=.tox,dist,doc,.env --ignore=E128
+commands = pycodestyle --exclude=.tox,dist,doc,.env --ignore=E128

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@ skip_missing_interpreters=True
 
 [testenv] 
 deps = -r{toxinidir}/tools/test-requires
-commands = nosetests {posargs}
+commands =
+    pytest {toxinidir}/stoplight/tests --cov-config=.coveragerc --cov=stoplight {posargs}
 
 [testenv:pep8]
 deps = pycodestyle


### PR DESCRIPTION
- pep8 has been replaced by pycodestyle
  - fix some pep8 errors that were reported as a result
- nosetests are no longer maintained, updating to pytest
- dropping `--use-mirror` from `pip install` as it's no longer supported (commit shared with #12 that does the same thing so I can get the travis-ci builds to work).
- pin dependencies