### PR TITLE
Avoid DeprecationWarning on Python 3

### DIFF
--- a/stoplight/decorators.py
+++ b/stoplight/decorators.py
@@ -98,7 +98,11 @@ def validate(*freerules, **paramrules):
                 if _apply_rule(f, rule, None, rule.getter) is not None:
                     return
 
-            funcparams = inspect.getargspec(f)
+            try:
+                funcparams = inspect.getfullargspec(f)
+            except AttributeError:
+                # running on Python 2
+                funcparams = inspect.getargspec(f)
 
             # Holds the list of validated values. Only
             # these values are passed to the decorated function

--- a/stoplight/rule.py
+++ b/stoplight/rule.py
@@ -44,7 +44,12 @@ class Rule(object):
         passing the failure_info parameter to the error handler
         if it expects a parameter"""
 
-        if inspect.getargspec(self.errfunc).args == []:
+        try:
+            spec = inspect.getfullargspec(self.errfunc)
+        except AttributeError:
+            # running on Python 2
+            spec = inspect.getargspec(self.errfunc)
+        if spec.args == []:
             self.errfunc()
         else:
             self.errfunc(failure_info)


### PR DESCRIPTION
Since Python 3.0, `inspect.getargspec` has been deprecated in
favor of `inspect.getfullargspec`. Both are `namedtuple`s which
provide the `args` attribute, so it's a drop-in replacement for
this project's needs.

Use a try/catch `AttributeError` to preserve Python 2 compatibility.

Fixes #19.