### PR TITLE
Version Bump: 1.4.0 -> 1.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md') as description_input:
 
 setup(
     name='stoplight',
-    version='1.4.0',
+    version='1.4.1',
     description='Input validation framework for Python',
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/x-md',


### PR DESCRIPTION
Bumping version to 1.4.1 for release since 1.4.0 already exists as a tag.